### PR TITLE
Deps updates

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -2,7 +2,7 @@ export * as ConsoleColor from "https://deno.land/x/colorlog@v1.0/mod.ts";
 
 // NOTE: Migrate to the official https://github.com/aghussb/dex when it's updated to the
 //       latest deno version.
-export { default as SQLQueryBuilder } from "https://raw.githubusercontent.com/jerlam06/dex/std-downgrade/mod-dyn.ts";
+export { default as SQLQueryBuilder } from "https://raw.githubusercontent.com/Rushmore75/dex/master/mod-dyn.ts";
 
 export { camelCase, snakeCase } from "https://deno.land/x/case@v2.1.0/mod.ts";
 

--- a/deps.ts
+++ b/deps.ts
@@ -13,7 +13,7 @@ export {
 } from "https://deno.land/x/mysql@v2.11.0/mod.ts";
 export type { LoggerConfig } from "https://deno.land/x/mysql@v2.11.0/mod.ts";
 
-export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.14.2/mod.ts";
+export { Client as PostgresClient } from "https://deno.land/x/postgres@v0.17.0/mod.ts";
 
 export { DB as SQLiteClient } from "https://deno.land/x/sqlite@v3.1.3/mod.ts";
 


### PR DESCRIPTION
PostgresClient can be updated without error, and I also changed to my version of Dex. However, I also submitted a pull request to your Dex version. So if that gets accepted you could change it back to your version again.

The old version of Dex was giving some errors as pointed out in https://github.com/jerlam06/dex/pull/1